### PR TITLE
ECOM: Implemented the Model Mapper in the app to include the DTO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.modelmapper</groupId>
+            <artifactId>modelmapper</artifactId>
+            <version>3.2.4</version>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/com/ecommerce/sb_ecom_project/config/AppConfig.java
+++ b/src/main/java/com/ecommerce/sb_ecom_project/config/AppConfig.java
@@ -1,0 +1,14 @@
+package com.ecommerce.sb_ecom_project.config;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public ModelMapper modelMapper(){
+        return new ModelMapper();
+    }
+}

--- a/src/main/java/com/ecommerce/sb_ecom_project/controller/CategoryController.java
+++ b/src/main/java/com/ecommerce/sb_ecom_project/controller/CategoryController.java
@@ -1,6 +1,6 @@
 package com.ecommerce.sb_ecom_project.controller;
 
-import com.ecommerce.sb_ecom_project.model.Category;
+import com.ecommerce.sb_ecom_project.payload.CategoryDTO;
 import com.ecommerce.sb_ecom_project.service.CategoryService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -20,15 +20,16 @@ public class CategoryController {
         this.categoryService = categoryService;
     }
 
+
     @GetMapping("/api/public/categories")
-    public List<Category> getAllCategories() {
+    public List<CategoryDTO> getAllCategories() {
         return categoryService.getAllCategories();
     }
 
     @PostMapping("/api/public/categories")
-    public String createCategory(@Valid @RequestBody Category category) {
-        categoryService.createCategory(category);
-        return "Category added successfully";
+    public ResponseEntity<String> createCategory(@Valid @RequestBody CategoryDTO categoryDTO) {
+        categoryService.createCategory(categoryDTO);
+        return ResponseEntity.ok("Category created successfully");
     }
 
     @DeleteMapping("/api/admin/categories/{categoryId}")
@@ -42,11 +43,11 @@ public class CategoryController {
     }
 
     @PutMapping("/api/admin/updateCategories/{categoryId}")
-    public ResponseEntity<Category> updateCategory(
-            @RequestBody Category category,
+    public ResponseEntity<CategoryDTO> updateCategory(
+            @RequestBody CategoryDTO categoryDTO,
             @PathVariable int categoryId) {
         try {
-            Category updatedCategory = categoryService.updateCategory(category, categoryId);
+            CategoryDTO updatedCategory = categoryService.updateCategory(categoryDTO, categoryId);
             return new ResponseEntity<>(updatedCategory, HttpStatus.OK);
         } catch (ResponseStatusException e) {
             return new ResponseEntity<>(null, e.getStatusCode());

--- a/src/main/java/com/ecommerce/sb_ecom_project/model/Category.java
+++ b/src/main/java/com/ecommerce/sb_ecom_project/model/Category.java
@@ -26,5 +26,5 @@ public class Category {
     private String categoryDescription;
     @AssertTrue(message = "Please mark the field as active")
     @JsonProperty("isActive")
-    private boolean isActive;
+    private boolean markActive;
 }

--- a/src/main/java/com/ecommerce/sb_ecom_project/payload/CategoryDTO.java
+++ b/src/main/java/com/ecommerce/sb_ecom_project/payload/CategoryDTO.java
@@ -1,0 +1,19 @@
+package com.ecommerce.sb_ecom_project.payload;
+
+
+import jakarta.validation.constraints.AssertTrue;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+/// Purpose: represents the data structure you accept as input or sometimes what you want to expose internally.
+
+@Data // it helps generating getter,setter,toString(), equals() and hashcode() for all the fields in the class.
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryDTO {
+    private long categoryId;
+    private String categoryName;
+    private String categoryDescription;
+    private boolean markActive;
+
+}

--- a/src/main/java/com/ecommerce/sb_ecom_project/payload/CategoryResponse.java
+++ b/src/main/java/com/ecommerce/sb_ecom_project/payload/CategoryResponse.java
@@ -1,0 +1,16 @@
+package com.ecommerce.sb_ecom_project.payload;
+// Purpose: represents the output format of your API.
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryResponse {
+    private List<CategoryDTO> content;
+
+}

--- a/src/main/java/com/ecommerce/sb_ecom_project/service/CategoryService.java
+++ b/src/main/java/com/ecommerce/sb_ecom_project/service/CategoryService.java
@@ -1,12 +1,13 @@
 package com.ecommerce.sb_ecom_project.service;
 
 import com.ecommerce.sb_ecom_project.model.Category;
+import com.ecommerce.sb_ecom_project.payload.CategoryDTO;
 
 import java.util.List;
 
 public interface CategoryService {
-    List<Category>  getAllCategories();
-    void createCategory(Category category);
+    List<CategoryDTO>  getAllCategories();
+    CategoryDTO createCategory(CategoryDTO categoryDTO);
     String deleteCategory(int categoryId);
-    Category updateCategory(Category category,int categoryId);
+    CategoryDTO updateCategory(CategoryDTO categoryDTO,int categoryId);
 }

--- a/src/main/java/com/ecommerce/sb_ecom_project/service/CategoryServiceImpl.java
+++ b/src/main/java/com/ecommerce/sb_ecom_project/service/CategoryServiceImpl.java
@@ -2,7 +2,9 @@ package com.ecommerce.sb_ecom_project.service;
 
 import com.ecommerce.sb_ecom_project.exception.APIException;
 import com.ecommerce.sb_ecom_project.model.Category;
+import com.ecommerce.sb_ecom_project.payload.CategoryDTO;
 import com.ecommerce.sb_ecom_project.repository.CategoryRepository;
+import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -20,23 +22,39 @@ public class CategoryServiceImpl implements CategoryService {
     @Autowired
     private CategoryRepository categoryRepository;
 
+    @Autowired
+    private ModelMapper modelMapper;
+
     @Override
-    public List<Category> getAllCategories() {
+    public List<CategoryDTO> getAllCategories() {
         List<Category> categories = categoryRepository.findAll();
         if(categories.isEmpty()){
             throw new APIException("There is no category present in the database, Please add a category");
         }else{
-            return categoryRepository.findAll();
+            return categories.stream()
+                    .map(category -> modelMapper.map(category, CategoryDTO.class))
+                    .toList();
         }
     }
 
     @Override
-    public void createCategory(Category category) {
-        Optional<Category> existingCategory = categoryRepository.findByCategoryName(category.getCategoryName());
-        if (existingCategory.isPresent()) {
-            throw new APIException("Category name already exists: " + category.getCategoryName()+" Please change the category name");
+    public CategoryDTO createCategory(CategoryDTO categoryDTO) {
+        Optional<Category> existingCategory = categoryRepository.findByCategoryName(categoryDTO.getCategoryName());
+        if(categoryDTO.getCategoryDescription()!=null){
+            String desc = categoryDTO.getCategoryDescription().replace("{categoryName}",categoryDTO.getCategoryName());
+            categoryDTO.setCategoryDescription(desc);
         }
-        categoryRepository.save(category);
+        if (existingCategory.isPresent()) {
+            throw new APIException("Category name already exists: " + categoryDTO.getCategoryName()+" Please change the category name");
+        }
+        //convert DTO -> entity
+        Category category = modelMapper.map(categoryDTO, Category.class);
+
+        // Save Entity
+        Category savedCategory = categoryRepository.save(category);
+
+        //convert entity back to dto and return
+        return modelMapper.map(savedCategory,CategoryDTO.class);
     }
 
     @Override
@@ -51,14 +69,20 @@ public class CategoryServiceImpl implements CategoryService {
     }
 
     @Override
-    public Category updateCategory(Category category, int categoryId) {
+    public CategoryDTO updateCategory(CategoryDTO categoryDTO, int categoryId) {
+        // 1. Find the existing category from DB
         Category existingCategory = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new ResourceNotFoundException("Category","categoryID",categoryId));
 
-        existingCategory.setCategoryName(category.getCategoryName());
-        existingCategory.setCategoryDescription(category.getCategoryDescription());
-        existingCategory.setActive(category.isActive());
+        // 2. Update fields of existingCategory with values coming from input `category`
+        existingCategory.setCategoryName(categoryDTO.getCategoryName());
+        existingCategory.setCategoryDescription(categoryDTO.getCategoryDescription());
+        existingCategory.setMarkActive(categoryDTO.isMarkActive());
 
-        return categoryRepository.save(existingCategory);
+        //save the updated entity
+        Category savedCategory = categoryRepository.save(existingCategory);
+
+        //converting back to dto
+        return modelMapper.map(savedCategory, CategoryDTO.class);
     }
 }


### PR DESCRIPTION
- Implemented CategoryDTO and mapping with ModelMapper

- Introduced CategoryDTO to decouple API layer from entity layer.

- Added ModelMapper for entity ↔ DTO conversion.

- Updated CategoryService and CategoryController to return DTOs instead of entities.

- Ensured request/response bodies are clean and don’t expose internal entity details.
 
- Added logic to replace {categoryName} placeholder dynamically in categoryDescription